### PR TITLE
fix logo background

### DIFF
--- a/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.jelly
@@ -41,7 +41,7 @@ a.custom-header__link {
     height: 100%;
     padding:  16px 16px 16px 16px;
     clip-path: polygon(0 0, 95% 0, 100% 50%, 95% 100%, 0 100%);
-    background-color: var(--logo-bg);
+    background-color: var(--background);
     color: var(--text-color);
     font-size: 150%;
     font-weight: bold;

--- a/src/main/webapp/css/custom-header.css
+++ b/src/main/webapp/css/custom-header.css
@@ -29,7 +29,7 @@ a.custom-header__link {
   height: 100%;
   padding:  16px 16px 16px 16px;
   clip-path: polygon(0 0, 95% 0, 100% 50%, 95% 100%, 0 100%);
-  background-color: var(--logo-bg);
+  background-color: var(--background);
   color: var(--text-color);
   font-size: 150%;
   font-weight: bold;


### PR DESCRIPTION
fixes #13 

The `--logo-bg` css var was removed from core and dark theme plugin. This caused the wrong background color to be used by the logo link. Use var `--background` instead.


### Testing done

manually verified that `--background` is used and looks as expected

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
