### PR TITLE
do not apply theme on Jenkins Header

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderDecorator.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderDecorator.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.customizable_header;
 
 import hudson.Extension;
 import hudson.model.PageDecorator;
+import io.jenkins.plugins.customizable_header.headers.JenkinsHeaderSelector;
 import io.jenkins.plugins.customizable_header.logo.ImageLogo;
 import io.jenkins.plugins.customizable_header.logo.Logo;
 import org.jenkinsci.Symbol;
@@ -27,5 +28,9 @@ public class CustomHeaderDecorator extends PageDecorator {
       return ((ImageLogo) logo).getUrl();
     }
     return "";
+  }
+
+  public boolean isEnabled() {
+    return !(CustomHeaderConfiguration.get().getActiveHeader() instanceof JenkinsHeaderSelector);
   }
 }

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderDecorator/header.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderDecorator/header.jelly
@@ -1,16 +1,18 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-  <link rel="preload" href="${rootURL}/customizable-header/theme" as="style"/>
-  <link rel="stylesheet" href="${rootURL}/customizable-header/theme" type="text/css"/>
-  <j:if test="${it.cssResourceUrl != ''}">
-    <link rel="preload" href="${it.cssResourceUrl}" as="style"/>
-    <link rel="stylesheet" href="${it.cssResourceUrl}" type="text/css"/>
+  <j:if test="${it.enabled}">
+    <link rel="preload" href="${rootURL}/customizable-header/theme" as="style"/>
+    <link rel="stylesheet" href="${rootURL}/customizable-header/theme" type="text/css"/>
+    <j:if test="${it.cssResourceUrl != ''}">
+      <link rel="preload" href="${it.cssResourceUrl}" as="style"/>
+      <link rel="stylesheet" href="${it.cssResourceUrl}" type="text/css"/>
+    </j:if>
+    <j:if test="${it.imageLogo}">
+      <link rel="preload" href="${it.imageUrl}" as="image"/>
+    </j:if>
+    <j:if test="${it.hasLinks()}">
+      <script src="${rootURL}/plugin/customizable-header/js/bundles/app-nav.js" type="text/javascript"></script>
+    </j:if>
+    <script src="${resURL}/jsbundles/keyboard-shortcuts.js" type="text/javascript"></script>
   </j:if>
-  <j:if test="${it.imageLogo}">
-    <link rel="preload" href="${it.imageUrl}" as="image"/>
-  </j:if>
-  <j:if test="${it.hasLinks()}">
-    <script src="${rootURL}/plugin/customizable-header/js/bundles/app-nav.js" type="text/javascript"></script>
-  </j:if>
-  <script src="${resURL}/jsbundles/keyboard-shortcuts.js" type="text/javascript"></script>
 </j:jelly>


### PR DESCRIPTION
The theme should not be loaded when the Jenkins Header is used. Either because the Custom header is disabled or because the Jenkins Header is selected globally or via a user setting.

fixes #70

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
