### PR TITLE
use alert for the system message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.426.1</jenkins.version>
+    <jenkins.version>2.440.2</jenkins.version>
     <gitHubRepo>jenkinsci/customizable-header-plugin</gitHubRepo>
     <node.version>20.8.0</node.version>
     <yarn.version>1.22.19</yarn.version>
@@ -44,8 +44,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.426.x</artifactId>
-        <version>2815.vf5d6f093b_23e</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>2961.v1f472390972e</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
@@ -79,7 +79,7 @@ public class CustomHeaderConfiguration extends GlobalConfiguration {
 
   public Object readResolve() {
     if (systemMessage == null) {
-      systemMessage = new SystemMessage("", SystemMessage.SystemMessageColor.lightyellow);
+      systemMessage = new SystemMessage("", SystemMessage.SystemMessageColor.info);
     }
     return this;
   }

--- a/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
@@ -5,6 +5,7 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 public class SystemMessage extends AbstractDescribableImpl<SystemMessage> {
   private final String message;
@@ -18,7 +19,9 @@ public class SystemMessage extends AbstractDescribableImpl<SystemMessage> {
     this.level = level;
   }
 
-  public Object readResolve() {
+  @DataBoundSetter
+  @Deprecated
+  public void setColor(String color) {
     if (color != null) {
       if (color.equals("lightyellow")) {
         level = SystemMessageColor.info;
@@ -30,6 +33,10 @@ public class SystemMessage extends AbstractDescribableImpl<SystemMessage> {
         level = SystemMessageColor.info;
       }
     }
+  }
+
+  public Object readResolve() {
+    setColor(color);
     return this;
   }
 
@@ -39,6 +46,10 @@ public class SystemMessage extends AbstractDescribableImpl<SystemMessage> {
 
   public SystemMessageColor getLevel() {
     return level;
+  }
+
+  public String getColor() {
+    return color;
   }
 
   @Extension

--- a/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
@@ -8,20 +8,37 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public class SystemMessage extends AbstractDescribableImpl<SystemMessage> {
   private final String message;
-  private final SystemMessageColor color;
+  private transient String color;
+
+  private SystemMessageColor level;
 
   @DataBoundConstructor
-  public SystemMessage(String message, SystemMessageColor color) {
+  public SystemMessage(String message, SystemMessageColor level) {
     this.message = message;
-    this.color = color;
+    this.level = level;
+  }
+
+  public Object readResolve() {
+    if (color != null) {
+      if (color.equals("lightyellow")) {
+        level = SystemMessageColor.info;
+      }
+      if (color.equals("red")) {
+        level = SystemMessageColor.info;
+      }
+      if (color.equals("orange")) {
+        level = SystemMessageColor.info;
+      }
+    }
+    return this;
   }
 
   public String getMessage() {
     return message;
   }
 
-  public SystemMessageColor getColor() {
-    return color;
+  public SystemMessageColor getLevel() {
+    return level;
   }
 
   @Extension
@@ -34,8 +51,8 @@ public class SystemMessage extends AbstractDescribableImpl<SystemMessage> {
 
   }
 
-  public static enum SystemMessageColor {
-    red, orange, lightyellow;
+  public enum SystemMessageColor {
+    danger, warning, info, success;
   }
 
 }

--- a/src/main/java/io/jenkins/plugins/customizable_header/headers/LogoHeader.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/headers/LogoHeader.java
@@ -53,9 +53,9 @@ public class LogoHeader extends PartialHeader {
   public String getSystemMessageColor() {
     SystemMessage systemMessage = CustomHeaderConfiguration.get().getSystemMessage();
     if (systemMessage == null) {
-      return "";
+      return "info";
     }
-    return systemMessage.getColor().name();
+    return systemMessage.getLevel().name();
   }
 
   public Logo getLogo() {

--- a/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.jelly
@@ -73,7 +73,7 @@
 
 .custom-header__system-message-header {
   padding: 5px 1.15rem;
-  margin-bottom: 0;
+  margin: 0;
 }
 
 .custom-header {

--- a/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.jelly
@@ -71,26 +71,9 @@
   cursor: pointer;
 }
 
-.custom-header__system-message-header-red {
-  background-color: red;
-  color: white;
-}
-
-.custom-header__system-message-header-orange {
-  background-color: darkorange;
-  color: white;
-}
-
-.custom-header__system-message-header-lightyellow {
-  background-color: lightyellow;
-  color: coral;
-}
-
 .custom-header__system-message-header {
-  min-height: 1.5rem;
-  justify-content: center;
-  align-items: center;
-  display: flex;
+  padding: 5px 1.15rem;
+  margin-bottom: 0;
 }
 
 .custom-header {

--- a/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/config.jelly
@@ -3,7 +3,7 @@
   <f:entry field="message" title="System Message">
     <f:textarea/>
   </f:entry>
-  <f:entry field="color" title="Background of System Message">
+  <f:entry field="level" title="Background of System Message">
     <f:enum>${it.toString()}</f:enum>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/LogoHeader/headerContent.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/LogoHeader/headerContent.jelly
@@ -76,10 +76,8 @@
         </div>
     </header>
     <j:if test="${it.systemMessage != ''}">
-        <header class="custom-header__system-message-header custom-header__system-message-header-${it.systemMessageColor}">
-            <div class="custom-header__system-message">
-                <j:out value="${it.systemMessage}"/>
-            </div>
-        </header>
+        <div class="alert alert-${it.systemMessageColor} custom-header__system-message-header">
+            <j:out value="${it.systemMessage}"/>
+        </div>
     </j:if>
 </j:jelly>


### PR DESCRIPTION
the alert will take care of the proper coloring and is theme aware. convert the colors to the alert levels, maps
red -> danger
orange -> warning
lightyellow -> info

there is a new level success now.

This change might break CasC when a systemMessage is configured in CasC. Use 
```
configuration-as-code:
  deprecated: warn
```
or change `color` to `level` according to above mapping.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
