### PR TITLE
use header taglib to decouple from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.457-SNAPSHOT</jenkins.version>
+    <jenkins.version>2.459</jenkins.version>
     <gitHubRepo>jenkinsci/customizable-header-plugin</gitHubRepo>
     <node.version>20.8.0</node.version>
     <yarn.version>1.22.19</yarn.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.440.2</jenkins.version>
+    <jenkins.version>2.457-SNAPSHOT</jenkins.version>
     <gitHubRepo>jenkinsci/customizable-header-plugin</gitHubRepo>
     <node.version>20.8.0</node.version>
     <yarn.version>1.22.19</yarn.version>

--- a/src/main/java/io/jenkins/plugins/customizable_header/headers/LogoHeader.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/headers/LogoHeader.java
@@ -6,10 +6,10 @@ import io.jenkins.plugins.customizable_header.CustomHeaderConfiguration;
 import io.jenkins.plugins.customizable_header.logo.Logo;
 import java.io.IOException;
 import java.io.StringWriter;
-import jenkins.views.PartialHeader;
+import jenkins.views.FullHeader;
 
 @Extension(ordinal = 99999)
-public class LogoHeader extends PartialHeader implements SystemMessageProvider {
+public class LogoHeader extends FullHeader implements SystemMessageProvider {
 
   @Override
   public boolean isEnabled() {
@@ -36,10 +36,5 @@ public class LogoHeader extends PartialHeader implements SystemMessageProvider {
 
   public Logo getLogo() {
     return CustomHeaderConfiguration.get().getLogo();
-  }
-
-  @Override
-  public int getSupportedHeaderVersion() {
-    return 1;
   }
 }

--- a/src/main/java/io/jenkins/plugins/customizable_header/headers/LogoHeader.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/headers/LogoHeader.java
@@ -6,10 +6,10 @@ import io.jenkins.plugins.customizable_header.CustomHeaderConfiguration;
 import io.jenkins.plugins.customizable_header.logo.Logo;
 import java.io.IOException;
 import java.io.StringWriter;
-import jenkins.views.FullHeader;
+import jenkins.views.PartialHeader;
 
 @Extension(ordinal = 99999)
-public class LogoHeader extends FullHeader implements SystemMessageProvider {
+public class LogoHeader extends PartialHeader implements SystemMessageProvider {
 
   @Override
   public boolean isEnabled() {
@@ -36,5 +36,10 @@ public class LogoHeader extends FullHeader implements SystemMessageProvider {
 
   public Logo getLogo() {
     return CustomHeaderConfiguration.get().getLogo();
+  }
+
+  @Override
+  public int getSupportedHeaderVersion() {
+    return 1;
   }
 }

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderDecorator/header.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderDecorator/header.jelly
@@ -14,6 +14,5 @@
     <j:if test="${it.hasLinks()}">
       <script src="${rootURL}/plugin/customizable-header/js/bundles/app-nav.js" type="text/javascript"></script>
     </j:if>
-    <script src="${resURL}/jsbundles/keyboard-shortcuts.js" type="text/javascript"></script>
   </j:if>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsHeader/headerContent.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsHeader/headerContent.jelly
@@ -1,6 +1,12 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
-    <st:include page="headerContent" class="jenkins.views.JenkinsHeader"/>
+<j:jelly xmlns:j="jelly:core" xmlns:h="/lib/layout/header">
+
+  <header>
+    <h:logo/>
+    <h:searchbox/>
+    <h:login/>
+  </header>
+
     <j:if test="${it.systemMessage != ''}">
         <div class="alert alert-${it.systemMessageColor} custom-header__system-message-header">
             <j:out value="${it.systemMessage}"/>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsHeader/headerContent.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsHeader/headerContent.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:h="/lib/layout/header">
 
-  <header>
+  <header id="page-header" class="page-header">
     <h:logo/>
     <h:searchbox/>
     <h:login/>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/LogoHeader/headerContent.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/LogoHeader/headerContent.jelly
@@ -3,7 +3,7 @@
   <template id="custom-header-icons">
     <l:icon id="external-link" src="symbol-open-outline plugin-ionicons-api" class="icon-xs"/>
   </template>
-  <header id="header" class="page-header custom-header__page">
+  <header id="page-header" class="page-header custom-header__page">
     <j:if test="${it.hasLinks()}">
       <div class="custom-header__app-nav">
         <button class="custom-header__app-nav-button" data-href="${rootURL}/customizable-header/getLinks">

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/LogoHeader/headerContent.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/LogoHeader/headerContent.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:h="/lib/layout/header">
   <template id="custom-header-icons">
     <l:icon id="external-link" src="symbol-open-outline plugin-ionicons-api" class="icon-xs"/>
   </template>
@@ -21,63 +21,8 @@
       <j:out value="${it.title}"/>
     </div>
 
-    <div class="searchbox hidden-xs">
-      <!-- search box -->
-      <j:set var="searchURL" value="${h.searchURL}"/>
-      <form action="${searchURL}" method="get" style="position:relative;" class="no-json" name="search" role="search">
-        <!-- this div is used to calculate the width of the text box -->
-        <div id="search-box-sizer"/>
-        <div id="searchform">
-          <input name="q" placeholder="${searchPlaceholder}" id="search-box" class="main-search__input" value="${request.getParameter('q')}"
-                 role="searchbox"/>
-
-          <span class="main-search__icon-leading">
-            <l:icon src="symbol-search"/>
-          </span>
-          <a href="${searchHelpUrl}" class="main-search__icon-trailing">
-            <l:icon src="symbol-help-circle"/>
-          </a>
-
-          <div id="search-box-completion" data-search-url="${searchURL}"/>
-          <st:adjunct includes="jenkins.views.JenkinsHeader.search-box"/>
-        </div>
-      </form>
-    </div>
-
-    <div class="login page-header__hyperlinks">
-      <div id="visible-am-insertion" class="page-header__am-wrapper"/>
-      <div id="visible-sec-am-insertion" class="page-header__am-wrapper"/>
-
-      <!-- login field -->
-      <j:if test="${app.useSecurity}">
-        <j:choose>
-          <j:when test="${!h.isAnonymous()}">
-            <j:invokeStatic var="user" className="hudson.model.User" method="current"/>
-            <j:choose>
-              <j:when test="${user.fullName == null || user.fullName.trim().isEmpty()}">
-                <j:set var="userName" value="${user.id}"/>
-              </j:when>
-              <j:otherwise>
-                <j:set var="userName" value="${user.fullName}"/>
-              </j:otherwise>
-            </j:choose>
-            <a href="${rootURL}/${user.url}" class="model-link">
-              <l:icon src="symbol-person-circle" class="icon-md"/>
-              <span class="hidden-xs hidden-sm">${userName}</span>
-            </a>
-            <j:if test="${app.securityRealm.canLogOut()}">
-              <a href="${rootURL}/logout">
-                <l:icon src="symbol-log-out" class="icon-md"/>
-                <span class="hidden-xs hidden-sm">${logout}</span>
-              </a>
-            </j:if>
-          </j:when>
-          <j:otherwise>
-            <st:include it="${app.securityRealm}" page="loginLink.jelly"/>
-          </j:otherwise>
-        </j:choose>
-      </j:if>
-    </div>
+    <h:searchbox/>
+    <h:login/>
   </header>
   <j:if test="${it.systemMessage != ''}">
     <div class="alert alert-${it.systemMessageColor} custom-header__system-message-header">


### PR DESCRIPTION
since 2.459 core provides the logo, search box and login parts of the header via a taglib for easier reuse in plugins.
This avoids that we have to duplicate the code and do double maintenance.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
