### PR TITLE
workaround JENKINS-73114

### DIFF
--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsHeader/headerContent.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsHeader/headerContent.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <st:include page="headerContent" class="jenkins.views.JenkinsHeader"/>
     <j:if test="${it.systemMessage != ''}">
-        <div class="alert alert-${it.systemMessageColor} custom-header__system-message-header">
+        <div class="custom-header__alert-${it.systemMessageColor} custom-header__system-message-header">
             <j:out value="${it.systemMessage}"/>
         </div>
     </j:if>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/LogoHeader/headerContent.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/LogoHeader/headerContent.jelly
@@ -80,7 +80,7 @@
     </div>
   </header>
   <j:if test="${it.systemMessage != ''}">
-    <div class="alert alert-${it.systemMessageColor} custom-header__system-message-header">
+    <div class="custom-header__alert-${it.systemMessageColor} custom-header__system-message-header">
       <j:out value="${it.systemMessage}"/>
     </div>
   </j:if>

--- a/src/main/webapp/css/header.css
+++ b/src/main/webapp/css/header.css
@@ -1,4 +1,50 @@
 .custom-header__system-message-header {
   padding: 5px 1.15rem;
   margin: 0;
+  font-size: var(--font-size-sm);
+  border: 1px solid transparent;
+  border-radius: 10px;
+}
+
+.custom-header__system-message-header a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.custom-header__system-message-header a:hover,
+.custom-header__system-message-header a:focus,
+.custom-header__system-message-header a:active {
+  text-decoration: underline;
+}
+
+.custom-header__alert-success {
+  color: var(--alert-success-text-color);
+  background-color: var(--alert-success-bg-color);
+  border-color: var(--alert-success-border-color);
+}
+
+.custom-header__alert-info {
+  color: var(--alert-info-text-color);
+  background-color: var(--alert-info-bg-color);
+  border-color: var(--alert-info-border-color);
+}
+
+.custom-header__alert-warning {
+  color: var(--alert-warning-text-color);
+  background-color: var(--alert-warning-bg-color);
+  border-color: var(--alert-warning-border-color);
+}
+
+.custom-header__alert-warning p {
+  color: var(--alert-warning-text-color);
+}
+
+.custom-header__alert-danger {
+  color: var(--alert-danger-text-color);
+  background-color: var(--alert-danger-bg-color);
+  border-color: var(--alert-danger-border-color);
+}
+
+.custom-header__alert-danger p {
+  color: var(--alert-danger-text-color);
 }


### PR DESCRIPTION
as the the alert classes from Jenkins collide with those from boostrap, on some pages the system message is styled differently. This also affects admin monitors but this is out of control, To avoid this use selve defined classes that make use of the jenkins defined colors

fixes #99
<!-- Please describe your pull request here. -->

See [JENKINS-73114](https://issues.jenkins.io/browse/JENKINS-73114)

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
