### PR TITLE
fix null in userheader dismissed

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/UserHeader.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/UserHeader.java
@@ -72,6 +72,13 @@ public class UserHeader extends UserProperty {
     this.links = links;
   }
 
+  public Object readResolve() {
+    if (dismissedMessages == null) {
+      dismissedMessages = new HashSet<>();
+    }
+    return this;
+  }
+
   public Set<String> getDismissedMessages() {
     return dismissedMessages;
   }


### PR DESCRIPTION
when an existing user is loaded via xstream, dismissedMessages is not initialized when it is not contained in the xml. This then always throws an null error and system messages can't be shown.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
