### PR TITLE
fix NPE in user config reconfigure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.459</jenkins.version>
+    <jenkins.version>2.462.3</jenkins.version>
     <gitHubRepo>jenkinsci/customizable-header-plugin</gitHubRepo>
-    <node.version>20.8.0</node.version>
+    <node.version>20.18.0</node.version>
     <yarn.version>1.22.19</yarn.version>
     <hpi.compatibleSinceVersion>54</hpi.compatibleSinceVersion>
     <spotless.check.skip>false</spotless.check.skip>
@@ -46,8 +46,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.440.x</artifactId>
-        <version>3234.v5ca_5154341ef</version>
+        <artifactId>bom-2.462.x</artifactId>
+        <version>3435.v238d66a_043fb_</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/io/jenkins/plugins/customizable_header/HeaderRootAction.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/HeaderRootAction.java
@@ -100,7 +100,7 @@ public class HeaderRootAction implements UnprotectedRootAction {
     if (user != null) {
       UserHeader userHeader = user.getProperty(UserHeader.class);
       if (userHeader == null) {
-        userHeader = new UserHeader(false, false);
+        userHeader = new UserHeader();
         user.addProperty(userHeader);
       }
       userHeader.getDismissedMessages().add(uid);

--- a/src/main/java/io/jenkins/plugins/customizable_header/UserHeader.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/UserHeader.java
@@ -20,9 +20,9 @@ import org.kohsuke.stapler.StaplerRequest;
 
 public class UserHeader extends UserProperty {
 
-  private final boolean overwriteHeader;
+  private boolean overwriteHeader;
 
-  private final boolean overwriteColors;
+  private boolean overwriteColors;
   private HeaderColor headerColor;
 
   private HeaderSelector headerSelector;
@@ -32,13 +32,16 @@ public class UserHeader extends UserProperty {
   private Set<String> dismissedMessages = new HashSet<>();
 
   @DataBoundConstructor
-  public UserHeader(boolean overwriteHeader, boolean overwriteColors) {
-    this.overwriteHeader = overwriteHeader;
-    this.overwriteColors = overwriteColors;
+  public UserHeader() {
   }
 
   public boolean isOverwriteColors() {
     return overwriteColors;
+  }
+
+  @DataBoundSetter
+  public void setOverwriteColors(boolean overwriteColors) {
+    this.overwriteColors = overwriteColors;
   }
 
   @DataBoundSetter
@@ -57,6 +60,11 @@ public class UserHeader extends UserProperty {
 
   public HeaderSelector getHeaderSelector() {
     return headerSelector;
+  }
+
+  @DataBoundSetter
+  public void setOverwriteHeader(boolean overwriteHeader) {
+    this.overwriteHeader = overwriteHeader;
   }
 
   public boolean isOverwriteHeader() {
@@ -85,7 +93,9 @@ public class UserHeader extends UserProperty {
 
   @Override
   public UserProperty reconfigure(StaplerRequest req, @CheckForNull JSONObject form) {
-    links.clear();
+    if (links != null) {
+      links.clear();
+    }
     req.bindJSON(this, form);
     return this;
   }
@@ -96,7 +106,7 @@ public class UserHeader extends UserProperty {
 
     @Override
     public UserProperty newInstance(User user) {
-      UserHeader userHeader = new UserHeader(false, false);
+      UserHeader userHeader = new UserHeader();
       HeaderColor globalHeaderColor = CustomHeaderConfiguration.get().getHeaderColor();
       userHeader.setHeaderColor(new HeaderColor(globalHeaderColor));
       return userHeader;


### PR DESCRIPTION
most likely caused when updating the plugin after user specific links where added. In that case the links field is not initialized.

Also fix issue with overwriting header and colors not getting properly saved.

fixes #152

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
