### PR TITLE
Add permission concept for links

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/AppNavLink.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/AppNavLink.java
@@ -20,6 +20,7 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
+import hudson.security.Permission;
 
 @ExportedBean
 public class AppNavLink extends AbstractLink {
@@ -27,16 +28,16 @@ public class AppNavLink extends AbstractLink {
   private String url;
   private String label;
   private Logo logo;
-
   private boolean external;
-
   private transient String color = "";
+  private Permission permission;
 
   @DataBoundConstructor
-  public AppNavLink(String url, String label, Logo logo) {
+  public AppNavLink(String url, String label, Logo logo, Permission permission) {
     this.url = url;
     this.label = label;
     this.logo = logo;
+    this.permission = permission;
   }
 
   @Exported
@@ -83,6 +84,13 @@ public class AppNavLink extends AbstractLink {
     this.logo = logo;
   }
 
+  public Permission getPermission() {
+    return permission;
+  }
+
+  public void setPermission(Permission permission) {
+    this.permission = permission;
+  }
 
   @Exported
   @Override
@@ -92,6 +100,9 @@ public class AppNavLink extends AbstractLink {
 
   @Exported
   public String getLinkUrl() {
+    if (permission != null && !Jenkins.get().hasPermission(permission)) {
+      return null;
+    }
     try {
       URI uri = new URI(url);
       if (!uri.isAbsolute()) {

--- a/src/main/resources/io/jenkins/plugins/customizable_header/AppNavLink/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/AppNavLink/config.jelly
@@ -9,5 +9,8 @@
   <f:entry field="external" title="${%External}">
     <f:checkbox/>
   </f:entry>
+  <f:entry field="permission" title="${%Permission}">
+    <f:dropdownDescriptorSelector field="permission"/>
+  </f:entry>
   <f:dropdownDescriptorSelector field="logo" title="${%The logo to show}" descriptors="${descriptor.logoDescriptors}"/>
 </j:jelly>


### PR DESCRIPTION
### Fixes #78

## Add permission concept for links to restrict access based on user roles.

# Changes made

## 1. CustomHeaderConfiguration.java**
  - Add a new permission `VIEW_LINK`.
  - Update the `getLinks` method to filter links based on user permissions.

## 2. AppNavLink.java**
  - Add a new field `permission`.
  - Update the constructor to include the `permission` field.
  - Update the `getLinkUrl` method to check for the `permission` field.

## 3. config.jelly
  - Add a new entry for the `permission` field.

