### PR TITLE
fix NPE when UserHeader not found

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
@@ -221,7 +221,9 @@ public class CustomHeaderConfiguration extends GlobalConfiguration {
     User user = User.current();
     if (user != null) {
       UserHeader userHeader = user.getProperty(UserHeader.class);
-      return userHeader.getLinks() != null && userHeader.getLinks().size() != 0;
+      if (userHeader != null) {
+        return userHeader.getLinks() != null && userHeader.getLinks().size() != 0;
+      }
     }
     return false;
   }
@@ -235,7 +237,9 @@ public class CustomHeaderConfiguration extends GlobalConfiguration {
     List<AbstractLink> links = null;
     if (user != null) {
       UserHeader userHeader = user.getProperty(UserHeader.class);
-      links = userHeader.getLinks();
+      if (userHeader != null) {
+        links = userHeader.getLinks();
+      }
     }
     if (links != null) {
       return links;


### PR DESCRIPTION
When a user has never saved his configuration, there is no userHeader property. This leads to a NPE when checking for links.

fixes #169

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
