### PR TITLE
use ionicons-api as default plugin for links as well

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/AppNavLink.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/AppNavLink.java
@@ -142,7 +142,7 @@ public class AppNavLink extends AbstractLink {
     }
 
     if (!iconSrc.contains("plugin-")) {
-      return "";
+      return "ionicons-api";
     }
 
     String[] arr = iconSrc.split(" ");


### PR DESCRIPTION
For the header logo the ionicons-api plugin is searched by default when no plugin is defined. Apply the same behavior for usage of symbols in links to conform to the help.

fixes #173

### Testing done
Manual interactive testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
