### PR TITLE
Improve UI to select level of system messages

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
@@ -158,7 +158,17 @@ public class SystemMessage extends AbstractDescribableImpl<SystemMessage> {
   }
 
   public enum SystemMessageColor {
-    info, warning, danger, success;
+    info("Informational"), warning("Warning"), danger("Error"), success("Success");
+    private String text;
+
+    SystemMessageColor(String text) {
+      this.text = text;
+    }
+
+    public String getText() {
+      return text;
+    }
+
   }
 
 }

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:section title="${%Customizable Header}">
     <f:optionalBlock field="enabled" title="${%Enable}" inline="true">
-      <f:entry title="${%System Messages}">
+      <f:entry title="${%System Messages}" help="/plugin/customizable-header/help-systemMessage.html">
         <f:repeatableProperty field="systemMessages" add="${%Add System Message}" header="${%Message}">
           <f:repeatableDeleteButton/>
         </f:repeatableProperty>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/help-systemMessage.html
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/help-systemMessage.html
@@ -1,4 +1,0 @@
-<div>
-  Show a message with a selectable background below the header but above the breadcrumb, e.g. to announce a coming maintenance or ongoing incidents.
-  The message can contain html, e.g. to add a link.
-</div>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.jelly
@@ -120,6 +120,11 @@
   </j:if>
 }
 
+.ch-sm-label {
+  padding: 5px 10px;
+  margin-right: 20px;
+}
+
 a.custom-header__link:hover {
   text-decoration: none;
 }

--- a/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/config.jelly
@@ -3,13 +3,27 @@
   <f:entry>
     <f:textarea field="message"/>
   </f:entry>
-  <f:entry field="level" title="${%Background of System Message}">
-    <f:enum>${it.toString()}</f:enum>
+  <f:entry title="${%Background of System Message}">
+    <!-- <f:enum>${it.getText()}</f:enum> -->
+    <div class="jenkins-radio">
+      <input type="radio" name="level" value="info" class="jenkins-radio__input"
+             checked="${instance.level == 'info' || instance == null ? 'true' : null}" id="ch-sm-info"/>
+      <label for="ch-sm-info" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-info ch-sm-label">Informational</span></label>
+      <input type="radio" name="level" value="warning" class="jenkins-radio__input"
+             checked="${instance.level == 'warning' ? 'true' : null}" id="ch-sm-warning"/>
+      <label for="ch-sm-info" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-warning ch-sm-label">Warning</span></label>
+      <input type="radio" name="level" value="danger" class="jenkins-radio__input"
+             checked="${instance.level == 'danger' ? 'true' : null}" id="ch-sm-danger"/>
+      <label for="ch-sm-info" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-danger ch-sm-label">Error</span></label>
+      <input type="radio" name="level" value="success" class="jenkins-radio__input"
+             checked="${instance.level == 'success' ? 'true' : null}" id="ch-sm-success"/>
+      <label for="ch-sm-info" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-success ch-sm-label">Success</span></label>
+    </div>
   </f:entry>
   <f:entry field="expireDate" title="${%Expiration Time}">
     <div class="custom-header__system-message--expireDate" data-now="${descriptor.minDate}">
       <f:textbox checkDependsOn="" data-input=""/>
-      <button class="jenkins-button" type="button" data-toggle="" tooltip="Open datetime picker">
+      <button class="jenkins-button" type="button" data-toggle="" tooltip="Open calendar">
         <l:icon src="symbol-calendar-outline plugin-ionicons-api"/>
       </button>
     </div>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/config.jelly
@@ -4,20 +4,12 @@
     <f:textarea field="message"/>
   </f:entry>
   <f:entry title="${%Background of System Message}">
-    <!-- <f:enum>${it.getText()}</f:enum> -->
     <div class="jenkins-radio">
-      <input type="radio" name="level" value="info" class="jenkins-radio__input"
-             checked="${instance.level == 'info' || instance == null ? 'true' : null}" id="ch-sm-info"/>
-      <label for="ch-sm-info" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-info ch-sm-label">Informational</span></label>
-      <input type="radio" name="level" value="warning" class="jenkins-radio__input"
-             checked="${instance.level == 'warning' ? 'true' : null}" id="ch-sm-warning"/>
-      <label for="ch-sm-info" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-warning ch-sm-label">Warning</span></label>
-      <input type="radio" name="level" value="danger" class="jenkins-radio__input"
-             checked="${instance.level == 'danger' ? 'true' : null}" id="ch-sm-danger"/>
-      <label for="ch-sm-info" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-danger ch-sm-label">Error</span></label>
-      <input type="radio" name="level" value="success" class="jenkins-radio__input"
-             checked="${instance.level == 'success' ? 'true' : null}" id="ch-sm-success"/>
-      <label for="ch-sm-info" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-success ch-sm-label">Success</span></label>
+      <j:forEach var="it" items="${descriptor.getPropertyType(instance,'level').getEnumConstants()}">
+        <input type="radio" name="level" value="${it}" class="jenkins-radio__input"
+               checked="${(instance == null and it == 'info') || instance.level == it ? 'true' : null}" id="ch-sm-${it}"/>
+        <label for="ch-sm-${it}" class="jenkins-radio__label"><span class="jenkins-alert jenkins-alert-${it} ch-sm-label">${it.text}</span></label>
+      </j:forEach>
     </div>
   </f:entry>
   <f:entry field="expireDate" title="${%Expiration Time}">

--- a/src/main/webapp/help-systemMessage.html
+++ b/src/main/webapp/help-systemMessage.html
@@ -1,0 +1,5 @@
+<div>
+  Show a message with a selectable background below the header but above the breadcrumb, e.g. to announce a coming maintenance or ongoing incidents.<br/>
+  These messages can be dismissed on a per user basis.
+
+</div>


### PR DESCRIPTION
Use a set or radio button with a label that has the look of the system message instead of a drop down

fixes #181 

Before: 
![image](https://github.com/user-attachments/assets/1deb4619-8344-4ce7-87e5-167709b99ab8)

After:
![image](https://github.com/user-attachments/assets/105c86f8-b8ae-456d-b51b-be0b8d871032)

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
