### PR TITLE
Use global MarkupFormatter for headers and system message

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Logo and logo text form a hyperlink that gets you back to the Jenkins root page 
 
 ## The title
 Optionally an additional title can be shown after a separator. The title is formatted using the global markup
-formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>) and may contain html, e.g. to include a link
-to some other site. Css already takes care to make the link properly styled.
+formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>). Depending on the configured formatter it may
+contain html, e.g. to include a link to some other site. Css already takes care to make the link properly styled.
 
 ## Application links and favorites
 The plugin allows to configure additional links that are accessible via a button to the left of the logo. Users can define their personal
@@ -51,7 +51,8 @@ be added as well to this menu.
 One or more system messages can be shown between the header and the breadcrumb bar. This allows to notify users about important
 things related to the instance, e.g. a planned update of Jenkins, a downtime due to hardware replacement or an ongoing
 incident. The message is formatted using the global markup formatter (see <code>Manage Jenkins > Security > Markup
-Formatter</code>) and may contain html, e.g. to apply some simple styling or include a link with more details.<br/>
+Formatter</code>). Depending on the configured formatter it may contain html, e.g. to apply some simple styling or
+include a link with more details.<br/>
 System messages can have an expiration time to automatically remove them. They can be dismissed on a per-user basis (can be disabled). 
 
 ![System Message](/docs/pics/system-message.png)<br/>

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ By default, the text `Jenkins` is displayed. You can choose any text you like or
 Logo and logo text form a hyperlink that gets you back to the Jenkins root page (similar to the original header).
 
 ## The title
-Optionally an additional title can be shown after a separator. This can contain html (sanitized with owasp), e.g. to 
-include a link to some other site. Css already takes care to make the link properly styled.
+Optionally an additional title can be shown after a separator. The title is formatted using the global markup
+formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>) and may contain html, e.g. to include a link
+to some other site. Css already takes care to make the link properly styled.
 
 ## Application links and favorites
 The plugin allows to configure additional links that are accessible via a button to the left of the logo. Users can define their personal
@@ -48,9 +49,9 @@ be added as well to this menu.
 
 ## System Messages
 One or more system messages can be shown between the header and the breadcrumb bar. This allows to notify users about important
-things related to the instance, e.g. a planned update of Jenkins, a downtime due to hardware replacement or an ongoing 
-incident. You can include html (sanitized with owasp) in the message to apply some simple styling or include a link
-with more details.<br/>
+things related to the instance, e.g. a planned update of Jenkins, a downtime due to hardware replacement or an ongoing
+incident. The message is formatted using the global markup formatter (see <code>Manage Jenkins > Security > Markup
+Formatter</code>) and may contain html, e.g. to apply some simple styling or include a link with more details.<br/>
 System messages can have an expiration time to automatically remove them. They can be dismissed on a per-user basis (can be disabled). 
 
 ![System Message](/docs/pics/system-message.png)<br/>

--- a/pom.xml
+++ b/pom.xml
@@ -73,16 +73,17 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>antisamy-markup-formatter</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>favorite</artifactId>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>antisamy-markup-formatter</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.customizable_header;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
-import hudson.markup.RawHtmlMarkupFormatter;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.User;
@@ -13,6 +12,7 @@ import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -139,7 +139,7 @@ public class SystemMessage extends AbstractDescribableImpl<SystemMessage> {
 
     StringWriter writer = new StringWriter();
     try {
-      RawHtmlMarkupFormatter.INSTANCE.translate(message, writer);
+      Jenkins.get().getMarkupFormatter().translate(message, writer);
       return writer.toString();
     } catch (IOException e) {
       return "";

--- a/src/main/java/io/jenkins/plugins/customizable_header/headers/LogoHeader.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/headers/LogoHeader.java
@@ -1,11 +1,11 @@
 package io.jenkins.plugins.customizable_header.headers;
 
 import hudson.Extension;
-import hudson.markup.RawHtmlMarkupFormatter;
 import io.jenkins.plugins.customizable_header.CustomHeaderConfiguration;
 import io.jenkins.plugins.customizable_header.logo.Logo;
 import java.io.IOException;
 import java.io.StringWriter;
+import jenkins.model.Jenkins;
 import jenkins.views.PartialHeader;
 
 @Extension(ordinal = 99999)
@@ -19,7 +19,7 @@ public class LogoHeader extends PartialHeader implements SystemMessageProvider, 
   public String getTitle() {
     StringWriter writer = new StringWriter();
     try {
-      RawHtmlMarkupFormatter.INSTANCE.translate(CustomHeaderConfiguration.get().getTitle(), writer);
+      Jenkins.get().getMarkupFormatter().translate(CustomHeaderConfiguration.get().getTitle(), writer);
       return writer.toString();
     } catch (IOException e) {
       return "";

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:section title="${%Customizable Header}">
     <f:optionalBlock field="enabled" title="${%Enable}" inline="true">
-      <f:entry title="${%System Messages}" help="/plugin/customizable-header/help-systemMessage.html">
+      <f:entry title="${%System Messages}" help="${descriptor.getHelpFile('systemMessage')}">
         <f:repeatableProperty field="systemMessages" add="${%Add System Message}" header="${%Message}">
           <f:repeatableDeleteButton/>
         </f:repeatableProperty>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/help-title.html
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/help-title.html
@@ -1,4 +1,7 @@
 <div>
-    The title is displayed after the link and will use the colors defined here. You can include html here,
+    The title is displayed after the link and will use the colors defined here.
+    </br>
+    The title is formatted using the global markup formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>) and may contain html, e.g. to add a link.
+    </br>
     The default will already take care of properly styling the link.
 </div>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/help-title.html
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/help-title.html
@@ -1,7 +1,8 @@
 <div>
     The title is displayed after the link and will use the colors defined here.
     </br>
-    The title is formatted using the global markup formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>) and may contain html, e.g. to add a link.
+    The title is formatted using the global markup formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>).
+    Depending on the configured formatter it may contain html, e.g. to add a link.
     </br>
     The default will already take care of properly styling the link.
 </div>

--- a/src/main/webapp/help-systemMessage.html
+++ b/src/main/webapp/help-systemMessage.html
@@ -1,4 +1,7 @@
 <div>
-  Show a message with a selectable background below the header but above the breadcrumb, e.g. to announce a coming maintenance or ongoing incidents.<br/>
+  Show a message with a selectable background below the header but above the breadcrumb, e.g. to announce a coming maintenance or ongoing incidents.
+  </br>
   Optionally these messages can be made expiring on a given date and can be dismissed on a per-user basis.
+  </br>
+  The message is formatted using the global markup formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>) and may contain html, e.g. to add a link.
 </div>

--- a/src/main/webapp/help-systemMessage.html
+++ b/src/main/webapp/help-systemMessage.html
@@ -3,5 +3,6 @@
   </br>
   Optionally these messages can be made expiring on a given date and can be dismissed on a per-user basis.
   </br>
-  The message is formatted using the global markup formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>) and may contain html, e.g. to add a link.
+  The message is formatted using the global markup formatter (see <code>Manage Jenkins > Security > Markup Formatter</code>).
+  Depending on the configured formatter it may contain html, e.g. to add a link.
 </div>

--- a/src/test/java/io/jenkins/plugins/customizable_header/SystemMessageTest.java
+++ b/src/test/java/io/jenkins/plugins/customizable_header/SystemMessageTest.java
@@ -1,0 +1,49 @@
+package io.jenkins.plugins.customizable_header;
+
+import static io.jenkins.plugins.customizable_header.SystemMessage.DATE_INPUT_FORMATTER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.markup.MarkupFormatter;
+import hudson.markup.RawHtmlMarkupFormatter;
+import java.io.IOException;
+import java.io.Writer;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class SystemMessageTest {
+
+@Test
+void escapedMessage(@SuppressWarnings("unused") JenkinsRule r) {
+  // save message
+  SystemMessage saveMessage = new SystemMessage("Save message", SystemMessage.SystemMessageColor.success, null);
+  assertEquals("Save message", saveMessage.getEscapedMessage());
+
+  // expired message
+  SystemMessage expiredMessage = new SystemMessage("Expired message", SystemMessage.SystemMessageColor.warning, null);
+  expiredMessage.setExpireDate(LocalDateTime.now().minusHours(1).format(DATE_INPUT_FORMATTER));
+  assertEquals("", expiredMessage.getEscapedMessage());
+
+  // dangerous message with global formatter
+  SystemMessage dangerousMessage  = new SystemMessage("<script>alert('PWND!')</script>", SystemMessage.SystemMessageColor.danger, null);
+  assertEquals("&lt;script&gt;alert(&#039;PWND!&#039;)&lt;/script&gt;", dangerousMessage.getEscapedMessage());
+
+  // dangerous message with OWASP formatter
+  r.jenkins.setMarkupFormatter(RawHtmlMarkupFormatter.INSTANCE);
+  assertEquals("", dangerousMessage.getEscapedMessage());
+
+  // save message with broken formatter
+  MarkupFormatter formatter = new MarkupFormatter() {
+  @Override
+  public void translate(String markup, @NonNull Writer output) throws IOException {
+    throw new IOException("Oh no!");
+  }
+  };
+  r.jenkins.setMarkupFormatter(formatter);
+  assertEquals("", saveMessage.getEscapedMessage());
+}
+
+}

--- a/src/test/java/io/jenkins/plugins/customizable_header/headers/AbstractLogoHeaderTest.java
+++ b/src/test/java/io/jenkins/plugins/customizable_header/headers/AbstractLogoHeaderTest.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.customizable_header.headers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.markup.MarkupFormatter;
+import hudson.markup.RawHtmlMarkupFormatter;
+import io.jenkins.plugins.customizable_header.CustomHeaderConfiguration;
+import java.io.IOException;
+import java.io.Writer;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+abstract class AbstractLogoHeaderTest {
+
+  abstract LogoHeader getHeader();
+
+  @Test
+  void title(@SuppressWarnings("unused") JenkinsRule r) {
+    LogoHeader header = getHeader();
+
+    // save title
+    CustomHeaderConfiguration.get().setTitle("Save title");
+    assertEquals("Save title", header.getTitle());
+
+    // dangerous title with global formatter
+    CustomHeaderConfiguration.get().setTitle("<script>alert('PWND!')</script>");
+    assertEquals("&lt;script&gt;alert(&#039;PWND!&#039;)&lt;/script&gt;", header.getTitle());
+
+    // dangerous title with OWASP formatter
+    r.jenkins.setMarkupFormatter(RawHtmlMarkupFormatter.INSTANCE);
+    assertEquals("", header.getTitle());
+
+    // save title with broken formatter
+    MarkupFormatter formatter = new MarkupFormatter() {
+      @Override
+      public void translate(String markup, @NonNull Writer output) throws IOException {
+        throw new IOException("Oh no!");
+      }
+    };
+    r.jenkins.setMarkupFormatter(formatter);
+    assertEquals("", header.getTitle());
+  }
+}

--- a/src/test/java/io/jenkins/plugins/customizable_header/headers/ContextAwareHeaderTest.java
+++ b/src/test/java/io/jenkins/plugins/customizable_header/headers/ContextAwareHeaderTest.java
@@ -1,0 +1,12 @@
+package io.jenkins.plugins.customizable_header.headers;
+
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class ContextAwareHeaderTest extends AbstractLogoHeaderTest {
+
+  @Override
+  LogoHeader getHeader() {
+    return new ContextAwareHeader();
+  }
+}

--- a/src/test/java/io/jenkins/plugins/customizable_header/headers/LogoHeaderTest.java
+++ b/src/test/java/io/jenkins/plugins/customizable_header/headers/LogoHeaderTest.java
@@ -1,0 +1,12 @@
+package io.jenkins.plugins.customizable_header.headers;
+
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class LogoHeaderTest extends AbstractLogoHeaderTest {
+
+  @Override
+  LogoHeader getHeader() {
+    return new LogoHeader();
+  }
+}


### PR DESCRIPTION
See #182 for more details.

This can be considered a breaking change in case users relied on `RawHtmlMarkupFormatter` to format the texts and have a different global `MarkupFormatter` (e.g. `EscapedMarkupFormatter`) configured. 
However I think this behavior is way more consistent as plugins should not need to by-pass the global `MarkupFormatter`.

fix #182

### Testing done

Added tests to show that titles and messages are properly escaped using the global `MarkupFormatter`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
