### PR TITLE
Fix plugin loading when datadog is installed

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
@@ -122,7 +122,6 @@ public class CustomHeaderConfiguration extends GlobalConfiguration {
       enabled = false;
     }
     headerColor.setUserColors(false);
-    save();
     return this;
   }
 


### PR DESCRIPTION
With datadog plugin installed the call to save in readResolve triggers the saveable listener of the datadog plugin which then results in loading the current user. This tries to read the header configuration which is not yet properly initialized. The effect is that the header config is not there later breaking the UI completely.

fixes #219 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
