### PR TITLE
fix CasC when loading jenkins header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>antisamy-markup-formatter</artifactId>
       <scope>test</scope>

--- a/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
@@ -103,10 +103,7 @@ public class CustomHeaderConfiguration extends GlobalConfiguration {
     return result;
   }
 
-  public Object readResolve() {
-    if (systemMessage != null) {
-      systemMessages.add(systemMessage);
-    }
+  private void convertOldHeaders() {
     if (header instanceof ContextSelector cs) {
       contextAwareLogo = new ContextAwareLogo();
       contextAwareLogo.setShowFolderWeather(cs.isShowFolderWeather());
@@ -121,6 +118,13 @@ public class CustomHeaderConfiguration extends GlobalConfiguration {
       header = new JenkinsWrapperHeaderSelector();
       enabled = false;
     }
+  }
+
+  public Object readResolve() {
+    if (systemMessage != null) {
+      systemMessages.add(systemMessage);
+    }
+    convertOldHeaders();
     headerColor.setUserColors(false);
     return this;
   }
@@ -302,6 +306,7 @@ public class CustomHeaderConfiguration extends GlobalConfiguration {
   @DataBoundSetter
   public void setHeader(HeaderSelector header) {
     this.header = header;
+    convertOldHeaders();
     save();
   }
 

--- a/src/main/java/io/jenkins/plugins/customizable_header/color/HeaderColor.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/color/HeaderColor.java
@@ -9,12 +9,14 @@ import io.jenkins.plugins.customizable_header.CustomHeaderConfiguration;
 import io.jenkins.plugins.customizable_header.ThemeSample;
 import java.util.List;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Stapler;
 
 public class HeaderColor implements Describable<HeaderColor> {
 
   private final String backgroundColor;
   private final String color;
+  private transient String hoverColor;
   private Boolean userColors = null;
 
   @DataBoundConstructor
@@ -37,6 +39,16 @@ public class HeaderColor implements Describable<HeaderColor> {
       return false;
     }
     return userColors;
+  }
+
+  // just so loading an old CasC works
+  @DataBoundSetter
+  public void setHoverColor(String hoverColor) {
+    this.hoverColor = hoverColor;
+  }
+
+  public String getHoverColor() {
+    return hoverColor;
   }
 
   public String getBackgroundColor() {

--- a/src/main/java/io/jenkins/plugins/customizable_header/headers/JenkinsHeaderSelector.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/headers/JenkinsHeaderSelector.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.customizable_header.headers;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class JenkinsHeaderSelector extends HeaderSelector {
@@ -11,8 +10,7 @@ public class JenkinsHeaderSelector extends HeaderSelector {
   public JenkinsHeaderSelector() {
   }
 
-  @Extension
-  @Symbol("jenkins")
+  @Extension(ordinal = -9999)
   public static class DescriptorImpl extends HeaderDescriptor {
 
     @NonNull

--- a/src/main/java/io/jenkins/plugins/customizable_header/headers/JenkinsWrapperHeaderSelector.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/headers/JenkinsWrapperHeaderSelector.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.customizable_header.headers;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -16,7 +17,7 @@ public class JenkinsWrapperHeaderSelector extends HeaderSelector {
   }
 
   @Extension
-  @org.jenkinsci.Symbol("jenkins")
+  @Symbol("jenkins")
   public static class DescriptorImpl extends HeaderDescriptor {
     @NonNull
     @Override

--- a/src/test/java/io/jenkins/plugins/customizable_header/CasCTest.java
+++ b/src/test/java/io/jenkins/plugins/customizable_header/CasCTest.java
@@ -1,0 +1,99 @@
+package io.jenkins.plugins.customizable_header;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import io.jenkins.plugins.customizable_header.headers.JenkinsWrapperHeaderSelector;
+import io.jenkins.plugins.customizable_header.headers.SectionedHeaderSelector;
+import io.jenkins.plugins.customizable_header.logo.SvgLogo;
+import io.jenkins.plugins.customizable_header.logo.Symbol;
+import org.junit.jupiter.api.Test;
+
+@WithJenkinsConfiguredWithCode
+class CasCTest {
+
+  @Test
+  @ConfiguredWithCode("casc-old-logo-header.yaml")
+  void loadOldLogoHeader(JenkinsConfiguredWithCodeRule jcwcRule) {
+    CustomHeaderConfiguration config = CustomHeaderConfiguration.get();
+    assertThat(config.getHeader(), instanceOf(SectionedHeaderSelector.class));
+    assertThat(config.isEnabled(), is(true));
+    assertThat(config.isThinHeader(), is(true));
+    assertThat(config.getContextAwareLogo(), is(nullValue()));
+  }
+
+  @Test
+  @ConfiguredWithCode("casc-old-context-aware-header.yaml")
+  void loadOldContextAwareHeader(JenkinsConfiguredWithCodeRule jcwcRule) {
+    CustomHeaderConfiguration config = CustomHeaderConfiguration.get();
+    assertThat(config.getHeader(), instanceOf(SectionedHeaderSelector.class));
+    assertThat(config.isEnabled(), is(true));
+    assertThat(config.isThinHeader(), is(true));
+    assertThat(config.getContextAwareLogo().getShowFolderWeather(), is(true));
+    assertThat(config.getContextAwareLogo().getShowJobWeather(), is(true));
+  }
+
+  @Test
+  @ConfiguredWithCode("casc-old-jenkins-header.yaml")
+  void loadOldJenkinsHeader(JenkinsConfiguredWithCodeRule jcwcRule) {
+    CustomHeaderConfiguration config = CustomHeaderConfiguration.get();
+    assertThat(config.getHeader(), instanceOf(JenkinsWrapperHeaderSelector.class));
+    assertThat(config.isEnabled(), is(true));
+  }
+
+  @Test
+  @ConfiguredWithCode("casc-jenkins-header.yaml")
+  void loadJenkinsHeader(JenkinsConfiguredWithCodeRule jcwcRule) {
+    CustomHeaderConfiguration config = CustomHeaderConfiguration.get();
+    assertThat(config.getHeader(), instanceOf(JenkinsWrapperHeaderSelector.class));
+    assertThat(config.isEnabled(), is(true));
+    assertThat(config.getLogoText(), is("Jenkins"));
+    assertThat(config.getTitle(), is("CasC"));
+    assertThat(config.isThinHeader(), is(true));
+    assertThat(config.getHeaderColor().getColor(), is("var(--white)"));
+    assertThat(config.getHeaderColor().getBackgroundColor(), is("linear-gradient(90deg, rgba(28,99,190,1) 0%, rgba(53,224,192,1) 100%);"));
+    assertThat(config.getLogo(), instanceOf(SvgLogo.class));
+    assertThat(((SvgLogo) config.getLogo()).getLogoPath(), is("userContent/logo.svg"));
+  }
+
+  @Test
+  @ConfiguredWithCode("casc-sectioned-header.yaml")
+  void loadSectionedHeader(JenkinsConfiguredWithCodeRule jcwcRule) {
+    CustomHeaderConfiguration config = CustomHeaderConfiguration.get();
+    assertThat(config.getHeader(), instanceOf(SectionedHeaderSelector.class));
+    assertThat(config.isEnabled(), is(true));
+    assertThat(config.getLogoText(), is("Jenkins"));
+    assertThat(config.getTitle(), is("CasC"));
+    assertThat(config.isThinHeader(), is(true));
+  }
+
+  @Test
+  @ConfiguredWithCode("casc-sectioned-header.yaml")
+  void loadLinks(JenkinsConfiguredWithCodeRule jcwcRule) {
+    CustomHeaderConfiguration config = CustomHeaderConfiguration.get();
+    assertThat(config.getLinks(), is(notNullValue()));
+    assertThat(config.getLinks().size(), is(3));
+
+    assertThat(config.getLinks().get(0), instanceOf(AppNavLink.class));
+    assertThat(((AppNavLink) config.getLinks().get(0)).getLabel(), is("Google"));
+    assertThat(((AppNavLink) config.getLinks().get(0)).getUrl(), is("https://google.com"));
+    assertThat(((AppNavLink) config.getLinks().get(0)).getExternal(), is(false));
+    assertThat(((AppNavLink) config.getLinks().get(0)).getLogo(), instanceOf(SvgLogo.class));
+
+    assertThat(config.getLinks().get(1), instanceOf(LinkSeparator.class));
+    assertThat(((LinkSeparator) config.getLinks().get(1)).getTitle(), is("External"));
+
+    assertThat(config.getLinks().get(2), instanceOf(AppNavLink.class));
+    assertThat(((AppNavLink) config.getLinks().get(2)).getLabel(), is("Youtube"));
+    assertThat(((AppNavLink) config.getLinks().get(2)).getUrl(), is("https://youtube.com"));
+    assertThat(((AppNavLink) config.getLinks().get(2)).getExternal(), is(true));
+    assertThat(((AppNavLink) config.getLinks().get(2)).getLogo(), instanceOf(Symbol.class));
+  }
+
+}

--- a/src/test/resources/io/jenkins/plugins/customizable_header/casc-jenkins-header.yaml
+++ b/src/test/resources/io/jenkins/plugins/customizable_header/casc-jenkins-header.yaml
@@ -1,0 +1,13 @@
+appearance:
+  customHeader:
+    enabled: true
+    header: "jenkins"
+    headerColor:
+      backgroundColor: "linear-gradient(90deg, rgba(28,99,190,1) 0%, rgba(53,224,192,1) 100%);"
+      color: "var(--white)"
+    logo:
+      svg:
+        logoPath: "userContent/logo.svg"
+    logoText: "Jenkins"
+    thinHeader: true
+    title: "CasC"

--- a/src/test/resources/io/jenkins/plugins/customizable_header/casc-old-context-aware-header.yaml
+++ b/src/test/resources/io/jenkins/plugins/customizable_header/casc-old-context-aware-header.yaml
@@ -1,0 +1,26 @@
+appearance:
+  customHeader:
+    enabled: true
+    header:
+      context:
+        showFolderWeather: true
+        showJobWeather: true
+    headerColor:
+      backgroundColor: "linear-gradient(90deg, rgba(151,10,130,1) 0%, rgba(240,171,0,1)\
+        \ 100%);"
+      color: "white"
+      hoverColor: "#bb4a4e"
+    links:
+      - appNavLink:
+          external: true
+          label: "Google"
+          logo:
+            svg:
+              logoPath: "userContent/jira.svg"
+          url: "https://google.com"
+    logo:
+      svg:
+        logoPath: "userContent/logo.svg"
+    logoText: "Jenkins"
+    thinHeader: true
+    title: "CasC"

--- a/src/test/resources/io/jenkins/plugins/customizable_header/casc-old-jenkins-header.yaml
+++ b/src/test/resources/io/jenkins/plugins/customizable_header/casc-old-jenkins-header.yaml
@@ -1,0 +1,23 @@
+appearance:
+  customHeader:
+    enabled: true
+    header: "jenkins"
+    headerColor:
+      backgroundColor: "linear-gradient(90deg, rgba(151,10,130,1) 0%, rgba(240,171,0,1)\
+        \ 100%);"
+      color: "white"
+      hoverColor: "#bb4a4e"
+    links:
+      - appNavLink:
+          external: true
+          label: "Google"
+          logo:
+            svg:
+              logoPath: "userContent/jira.svg"
+          url: "https://google.com"
+    logo:
+      svg:
+        logoPath: "userContent/logo.svg"
+    logoText: "Jenkins"
+    thinHeader: true
+    title: "CasC"

--- a/src/test/resources/io/jenkins/plugins/customizable_header/casc-old-logo-header.yaml
+++ b/src/test/resources/io/jenkins/plugins/customizable_header/casc-old-logo-header.yaml
@@ -1,0 +1,23 @@
+appearance:
+  customHeader:
+    enabled: true
+    header: "logo"
+    headerColor:
+      backgroundColor: "linear-gradient(90deg, rgba(151,10,130,1) 0%, rgba(240,171,0,1)\
+        \ 100%);"
+      color: "white"
+      hoverColor: "#bb4a4e"
+    links:
+      - appNavLink:
+          external: true
+          label: "Google"
+          logo:
+            svg:
+              logoPath: "userContent/jira.svg"
+          url: "https://google.com"
+    logo:
+      svg:
+        logoPath: "userContent/logo.svg"
+    logoText: "Jenkins"
+    thinHeader: true
+    title: "CasC"

--- a/src/test/resources/io/jenkins/plugins/customizable_header/casc-sectioned-header.yaml
+++ b/src/test/resources/io/jenkins/plugins/customizable_header/casc-sectioned-header.yaml
@@ -1,0 +1,29 @@
+appearance:
+  customHeader:
+    enabled: true
+    header: "sectioned"
+    headerColor:
+      backgroundColor: "linear-gradient(90deg, rgba(28,99,190,1) 0%, rgba(53,224,192,1) 100%);"
+      color: "var(--white)"
+    links:
+      - appNavLink:
+          label: "Google"
+          logo:
+            svg:
+              logoPath: "userContent/logo.svg"
+          url: "https://google.com"
+      - linkSeparator:
+          title: "External"
+      - appNavLink:
+          external: true
+          label: "Youtube"
+          logo:
+            symbol:
+              symbol: "symbol-logo-youtube plugin-ionicons-api"
+          url: "https://youtube.com"
+    logo:
+      svg:
+        logoPath: "userContent/logo.svg"
+    logoText: "Jenkins"
+    thinHeader: true
+    title: "CasC"


### PR DESCRIPTION
due to a duplicate symbol loading CasC with `header: "jenkins"`  resulted in the old JenkinsHeaderSelector getting configured. But this no longer works resulting in no header getting applied.

Added CasC tests that loads old and current configs

the hoverColor no longer breaks loading of old CasC configs

fixes #167 
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
