### PR TITLE
Improve places that use text-color-secondary

### DIFF
--- a/src/main/js/app-nav/index.js
+++ b/src/main/js/app-nav/index.js
@@ -86,7 +86,7 @@ function init() {
         interactive: true,
         trigger: "click",
         allowHTML: true,
-        appendTo: document.getElementById("page-header"),
+        appendTo: () => document.body,
         placement: "bottom-start",
         arrow: false,
         theme: "dropdown",

--- a/src/main/webapp/css/header.css
+++ b/src/main/webapp/css/header.css
@@ -82,6 +82,9 @@
     border-color: var(--focus-input-border);
     box-shadow: 0 0 0 2px var(--focus-input-glow);
   }
+  &::placeholder {
+    color: oklch(from var(--text-color) 50% c h) !important;
+  }
 }
 
 .ch-search-symbol {


### PR DESCRIPTION
The header overwrites the text-color-secondary variable. Depending on theme and header color the placeholder and the separator in the app-nav menu become unreadable.
For placeholder use a color based on text-color.
For the app-nav menu attach it to the body instead of the header. This avoids that the secondary color from the header is used.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
