### PR TITLE
Hide header title on mobile

### DIFF
--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsWrapperHeader/logo.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsWrapperHeader/logo.jelly
@@ -14,7 +14,7 @@
     </a>
 
     <j:if test="${it.customizeAllowed and it.title != null and !(it.title eq '')}">
-        <div class="custom-header__title"><j:out value="${it.title}"/></div>
+        <div class="custom-header__title jenkins-mobile-hide"><j:out value="${it.title}"/></div>
     </j:if>
   </span>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/SectionedHeader/headerContent.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/SectionedHeader/headerContent.jelly
@@ -10,7 +10,7 @@
     <div class="ch-section-2 jenkins-header__main">
       <div class="jenkins-header__navigation">
         <j:if test="${it.title != null and !(it.title eq '')}">
-          <div class="custom-header__title"><j:out value="${it.title}"/></div>
+          <div class="custom-header__title jenkins-mobile-hide"><j:out value="${it.title}"/></div>
         </j:if>
         <l:breadcrumbBar>
           <j:out value="${breadcrumbs}" />


### PR DESCRIPTION
Small one to hide header titles on mobile. The title can cause the header to overflow, resulting in a broken mobile experience (see weekly.ci.jenkins.io on mobile).

<img width="590" alt="image" src="https://github.com/user-attachments/assets/21a7f200-3759-438f-83ac-e53dc622b9d4" />

---

**Before**
<img width="590" alt="image" src="https://github.com/user-attachments/assets/dedeffea-0d2f-47b1-8461-32a33b4e4bf1" />


**After**
<img width="590" alt="image" src="https://github.com/user-attachments/assets/293d1ab6-9c6c-4116-84dd-8a237120c11a" />


### Testing done

* Title appears on desktop
* Title does not appear on mobile

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
