### PR TITLE
Remove preload to fix Safari cache bug

### DIFF
--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderDecorator/header.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderDecorator/header.jelly
@@ -1,7 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <link rel="stylesheet" href="${resURL}/plugin/customizable-header/css/header.css" type="text/css"/>
-  <link rel="preload" href="${rootURL}/customizable-header/theme.css" as="style"/>
   <link rel="stylesheet" href="${rootURL}/customizable-header/theme.css" type="text/css"/>
   <script src="${resURL}/plugin/customizable-header/js/bundles/custom-header.js" type="text/javascript"></script>
   <j:if test="${it.enabled}">


### PR DESCRIPTION
Safari caches very aggressively for some reason, meaning that you need to do a hard reload to reflect changes to the header. I tried [custom headers to no avail,](https://stackoverflow.com/questions/48693693/macos-safari-caching-response-while-headers-specify-no-caching) the only thing that worked was removing the preload line.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
