### PR TITLE
Remove margin if there's no background

### DIFF
--- a/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.css.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.css.jelly
@@ -76,8 +76,8 @@
     <j:if test="${it.backgroundColor != null and !it.backgroundColor.equals('')}">
       background: ${it.backgroundColor};
       --header-background: ${it.backgroundColor};
+      margin-bottom: 1rem;
     </j:if>
-    margin-bottom: 1rem;
   </j:if>
 }
 


### PR DESCRIPTION
The margin shows when a background hasn't been set, causing an unnecessary gap between the header and app bar.

**Before**
<img width="568" alt="image" src="https://github.com/user-attachments/assets/3e02fc68-3e53-4367-9a1d-7bfa6336dcae" />

**After**
<img width="628" alt="image" src="https://github.com/user-attachments/assets/1139c727-df08-4102-8eaa-2dae441edb0b" />

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
