### PR TITLE
Re-allow empty logo text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.492</jenkins.baseline>
-    <jenkins.version>2.507</jenkins.version>
+    <jenkins.baseline>2.516</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/customizable-header-plugin</gitHubRepo>
     <node.version>20.18.0</node.version>
     <npm.version>10.9.1</npm.version>
@@ -50,7 +50,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4890.vfca_82c6741a_d</version>
+        <version>5085.v05cc65a_936d3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration.java
@@ -55,7 +55,7 @@ public class CustomHeaderConfiguration extends GlobalConfiguration {
 
   private String cssResource;
 
-  private String logoText = "";
+  private String logoText = "Jenkins";
 
   private Logo logo = new Symbol("symbol-jenkins");
 

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderConfiguration/config.jelly
@@ -26,7 +26,7 @@
       <f:optionalProperty field="contextAwareLogo" title="Context Aware Logo" help="/plugin/customizable-header/help/help-contextAwareLogo.html"/>
 
       <f:entry field="logoText" title="${%Text}">
-        <f:textbox placeholder="Jenkins" clazz="custom-header__text-input" />
+        <f:textbox clazz="custom-header__text-input" />
       </f:entry>
       <f:entry field="title" title="${%Title}">
         <f:textbox/>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.css.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.css.jelly
@@ -49,6 +49,7 @@
   .custom-header__text {
     font-size: 1.125rem;
     font-weight: 600;
+    text-wrap: nowrap;
   }
 
   .custom-header__logo {

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsWrapperHeader/logo.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/JenkinsWrapperHeader/logo.jelly
@@ -4,7 +4,7 @@
     <a href="${rootURL}/" class="app-jenkins-logo">
         <st:include page="logo" it="${it.logo}" />
         <j:choose>
-            <j:when test="${it.customizeAllowed and it.logoText != null and !(it.logoText eq '')}">
+            <j:when test="${it.customizeAllowed and it.logoText != null}">
                 <div class="custom-header__text">${it.logoText}</div>
             </j:when>
             <j:otherwise>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/headers/SectionedHeader/logo.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/headers/SectionedHeader/logo.jelly
@@ -3,7 +3,7 @@
     <a href="${rootURL}/" class="app-jenkins-logo">
         <st:include page="logo" it="${it.logo}" />
         <j:choose>
-            <j:when test="${it.logoText != null and !(it.logoText eq '')}">
+            <j:when test="${it.logoText != null}">
                 <div class="custom-header__text">${it.logoText}</div>
             </j:when>
             <j:otherwise>


### PR DESCRIPTION
With the old header it was easily possible remove the text after the logo. The new header forced `Jenkins` when the text was empty which should be considered an incompatible change. Only by adding some blanks the text would disappear.

fixes #243

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
