### PR TITLE
Automatically allow configured logo URLs in CSP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.516</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>2.539</jenkins.version>
     <gitHubRepo>jenkinsci/customizable-header-plugin</gitHubRepo>
     <node.version>20.18.0</node.version>
     <npm.version>10.9.1</npm.version>
@@ -80,6 +80,12 @@
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>favorite</artifactId>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-suppressions</artifactId>
+      <version>${access-modifier-checker.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>

--- a/src/main/java/io/jenkins/plugins/customizable_header/logo/ImageLogo.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/logo/ImageLogo.java
@@ -2,18 +2,30 @@ package io.jenkins.plugins.customizable_header.logo;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.ExtensionList;
 import java.net.URI;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import jenkins.security.csp.Contributor;
+import jenkins.security.csp.CspBuilder;
+import jenkins.security.csp.Directive;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class ImageLogo extends Logo {
+
+  private static final Logger LOGGER = Logger.getLogger(ImageLogo.class.getName());
 
   private String logoUrl;
 
   @DataBoundConstructor
   public ImageLogo(String logoUrl) {
     this.logoUrl = logoUrl;
+    LogoUrlContributor.allowLogoUrl(logoUrl);
   }
 
   public String getLogoUrl() {
@@ -28,6 +40,11 @@ public class ImageLogo extends Logo {
     return uri.toString();
   }
 
+  private Object readResolve() {
+    LogoUrlContributor.allowLogoUrl(logoUrl);
+    return this;
+  }
+
   @Extension
   @Symbol("image")
   public static class DescriptorImpl extends LogoDescriptor {
@@ -38,4 +55,29 @@ public class ImageLogo extends Logo {
     }
   }
 
+  @Extension
+  @Restricted(NoExternalUse.class)
+  @SuppressRestrictedWarnings({ Contributor.class, CspBuilder.class })
+  public static class LogoUrlContributor implements Contributor {
+    private String url;
+
+    @Override
+    public void apply(CspBuilder cspBuilder) {
+      if (url != null) {
+        cspBuilder.add(Directive.IMG_SRC, url);
+      }
+    }
+
+    public static void allowLogoUrl(String url) {
+      try {
+        URI uri = URI.create(url);
+        if (uri.isAbsolute()) {
+          // ImageLogo does not support scheme-relative URLs either
+          ExtensionList.lookupSingleton(LogoUrlContributor.class).url = url;
+        }
+      } catch (RuntimeException ex) {
+        LOGGER.log(Level.FINE, "Failed to allow logo URL: " + url, ex);
+      }
+    }
+  }
 }

--- a/src/test/java/io/jenkins/plugins/customizable_header/CspTest.java
+++ b/src/test/java/io/jenkins/plugins/customizable_header/CspTest.java
@@ -1,0 +1,49 @@
+package io.jenkins.plugins.customizable_header;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import hudson.ExtensionList;
+import io.jenkins.plugins.customizable_header.logo.ImageLogo;
+import java.io.IOException;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.jvnet.hudson.test.recipes.LocalData;
+import org.xml.sax.SAXException;
+
+@WithJenkins
+public class CspTest {
+    @Test
+    void testBasicConfiguration(JenkinsRule j) throws IOException, SAXException {
+        final CustomHeaderConfiguration configuration = ExtensionList.lookupSingleton(CustomHeaderConfiguration.class);
+        configuration.setLogo(new ImageLogo("https://example.com/logo.png"));
+        configuration.save();
+
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            final HtmlPage htmlPage = wc.goTo("");
+            assertThat(htmlPage.getWebResponse().getResponseHeaderValue("Content-Security-Policy"),
+                    org.hamcrest.Matchers.containsString("img-src 'self' data: https://example.com/logo.png"));
+        }
+
+        configuration.setLogo(new ImageLogo("https://example.org/logo.svg"));
+        configuration.save();
+
+        // New configuration replaced existing CSP entry
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            final HtmlPage htmlPage = wc.goTo("");
+            assertThat(htmlPage.getWebResponse().getResponseHeaderValue("Content-Security-Policy"),
+                    org.hamcrest.Matchers.containsString("img-src 'self' data: https://example.org/logo.svg"));
+        }
+    }
+
+    @Test
+    @LocalData
+    void testExistingConfiguration(JenkinsRule j) throws IOException, SAXException {
+        try (JenkinsRule.WebClient wc = j.createWebClient()) {
+            final HtmlPage htmlPage = wc.goTo("");
+            assertThat(htmlPage.getWebResponse().getResponseHeaderValue("Content-Security-Policy"),
+                    org.hamcrest.Matchers.containsString("img-src 'self' data: https://example.com/logo.png"));
+        }
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/customizable_header/CspTest/testExistingConfiguration/io.jenkins.plugins.customizable_header.CustomHeaderConfiguration.xml
+++ b/src/test/resources/io/jenkins/plugins/customizable_header/CspTest/testExistingConfiguration/io.jenkins.plugins.customizable_header.CustomHeaderConfiguration.xml
@@ -1,0 +1,19 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<io.jenkins.plugins.customizable__header.CustomHeaderConfiguration plugin="customizable-header@999999-SNAPSHOT">
+  <title></title>
+  <cssResource></cssResource>
+  <logoText>Jenkins</logoText>
+  <logo class="io.jenkins.plugins.customizable_header.logo.ImageLogo">
+    <logoUrl>https://example.com/logo.png</logoUrl>
+  </logo>
+  <header class="io.jenkins.plugins.customizable_header.headers.JenkinsWrapperHeaderSelector"/>
+  <enabled>true</enabled>
+  <headerColor>
+    <backgroundColor>black</backgroundColor>
+    <color>white</color>
+    <userColors>false</userColors>
+  </headerColor>
+  <thinHeader>false</thinHeader>
+  <systemMessages/>
+  <links/>
+</io.jenkins.plugins.customizable__header.CustomHeaderConfiguration>


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/customizable-header-plugin/issues/280.

One thing that's a little awkward API-wise is that calling the `ImageLogo` constructor (or deserializing it) already replaces the allowed logo URL. Besides potential timing issues, it might mess with programmatic use of these classes I'm unaware of.

A potential solution to that might be to use a cache with fairly aggressive expiration, at least one entry, and having the call to `#getUrl` refresh the entry. Let me know if you think this is necessary.

### Testing done

Interactive testing (the new logo is shown immediately on Manage Jenkins after saving the Appearance config); autotests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
