### PR TITLE
Symbols for system messages

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
@@ -27,6 +27,7 @@ public class SystemMessage implements Describable<SystemMessage> {
   private SystemMessageColor level;
   private LocalDateTime expireDate;
   private String uid;
+  private boolean includeSymbol;
 
   private Boolean dismissible = true;
 
@@ -38,6 +39,14 @@ public class SystemMessage implements Describable<SystemMessage> {
       uid = UUID.randomUUID().toString();
     }
     this.uid = uid;
+  }
+
+  public boolean isIncludeSymbol() {
+    return includeSymbol;
+  }
+  @DataBoundSetter
+  public void setIncludeSymbol(boolean includeSymbol) {
+    this.includeSymbol = includeSymbol;
   }
 
   public Boolean getDismissible() {

--- a/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/config.jelly
@@ -6,6 +6,9 @@
   <f:entry field="dismissible" title="${%Dismissible}">
     <f:checkbox default="true"/>
   </f:entry>
+  <f:entry field="includeSymbol" title="${%Show a symbol next to the message}">
+    <f:checkbox/>
+  </f:entry>
   <f:entry title="${%Background of System Message}">
     <div class="jenkins-radio">
       <j:forEach var="it" items="${descriptor.getPropertyType(instance,'level').getEnumConstants()}">

--- a/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/help-includeSymbol.html
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/help-includeSymbol.html
@@ -1,0 +1,3 @@
+<div>
+ When checked, the message will include a symbol on the left side that corresponds to the message level (background).
+</div>

--- a/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/SystemMessage/index.jelly
@@ -2,6 +2,19 @@
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" >
   <j:if test="${!it.dismissed}">
     <div class="jenkins-alert jenkins-alert-${it.level.name()} custom-header__system-message-header">
+      <j:if test="${it.includeSymbol}">
+        <j:choose>
+          <j:when test="${it.level == it.level.danger}">
+            <l:icon src="symbol-alert-circle-outline plugin-ionicons-api"/>
+          </j:when>
+          <j:when test="${it.level == it.level.warning}">
+            <l:icon src="symbol-warning-outline plugin-ionicons-api"/>
+          </j:when>
+          <j:otherwise>
+            <l:icon src="symbol-information-circle-outline plugin-ionicons-api"/>
+          </j:otherwise>
+        </j:choose>
+      </j:if>
       <div><j:out value="${it.escapedMessage}"/></div>
       <j:if test="${!h.isAnonymous() and it.dismissible}">
         <a href="#" class="ch-dismiss-link" tooltip="${%Dismiss message}" data-uid="${it.uid}">

--- a/src/main/webapp/css/header.css
+++ b/src/main/webapp/css/header.css
@@ -10,6 +10,12 @@
   display: flex;
   align-items: center;
   border-radius: 0;
+  gap: 0.5rem;
+}
+
+.custom-header__system-message-header svg {
+  width: 20px;
+  height: 20px;
 }
 
 .ch-dismiss-link {


### PR DESCRIPTION
Optionally include a symbol left of the sytem message. The symbol corresponds to the selected background.

fixes #282

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
