### PR TITLE
Allow to set includeSymbol in the addMessage api REST call

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ To be able to later delete a system message, pass an id parameter in the call. I
 
 Parameters:
 
-| Parameter    | required | description                                                  |
-|--------------|----------|--------------------------------------------------------------|
-| message      | true     | The message, can contain html                                |
-| level        | true     | Message level, one of `info`, `success`, `warning`, `danger` |
-| expireDate   | false    | Expiration date for the message, format: `yyyy-M-d H:m`      |
-| uid          | false    | An optional unique id                                        |
-| dismissible  | false    | Message can be dismissed by users, defaults to `true`        |
+| Parameter     | required | description                                                  |
+|---------------|----------|--------------------------------------------------------------|
+| message       | true     | The message, can contain html                                |
+| level         | true     | Message level, one of `info`, `success`, `warning`, `danger` |
+| expireDate    | false    | Expiration date for the message, format: `yyyy-M-d H:m`      |
+| uid           | false    | An optional unique id                                        |
+| dismissible   | false    | Message can be dismissed by users, defaults to `true`        |
+| includeSymbol | false    | Include a symbol in the message, defaults to `false`         |
 
 To delete a system message do a post request to `<jenkins_url>/customizable-header/deleteSystemMessage?id=<id>`
 
@@ -121,4 +122,5 @@ icon-health-80plus=file-userContent/svgs/mood-happy.svg
 #### Manage something
 ![Manage](docs/pics/manage-jenkins.png)<br/>
 ![Security](docs/pics/configure-security.png)
+
 

--- a/src/main/java/io/jenkins/plugins/customizable_header/HeaderRootAction.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/HeaderRootAction.java
@@ -80,7 +80,8 @@ public class HeaderRootAction implements UnprotectedRootAction {
 
   @POST
   public HttpResponse doAddSystemMessage(@QueryParameter(fixEmpty = true) String message, @QueryParameter(fixEmpty = true) String level,
-                                @QueryParameter String expireDate, @QueryParameter(fixEmpty = true) String id, @QueryParameter(fixEmpty = true) Boolean dismissible) throws IOException {
+                                @QueryParameter String expireDate, @QueryParameter(fixEmpty = true) String id, @QueryParameter(fixEmpty = true) Boolean dismissible,
+                                @QueryParameter(fixEmpty = true) Boolean includeSymbol) throws IOException {
     Jenkins.get().checkPermission(Jenkins.ADMINISTER);
     if (message == null || level == null) {
       throw HttpResponses.error(HttpServletResponse.SC_BAD_REQUEST, "Missing parameters: message and level are mandatory");
@@ -90,6 +91,9 @@ public class HeaderRootAction implements UnprotectedRootAction {
       SystemMessage msg = new SystemMessage(message, lvl, id);
       msg.setExpireDate(expireDate);
       msg.setDismissible(dismissible);
+      if (includeSymbol != null) {
+        msg.setIncludeSymbol(includeSymbol);
+      }
       CustomHeaderConfiguration config = CustomHeaderConfiguration.get();
       config.addSystemMessage(msg);
       return HttpResponses.text(msg.getUid());

--- a/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/SystemMessage.java
@@ -44,6 +44,7 @@ public class SystemMessage implements Describable<SystemMessage> {
   public boolean isIncludeSymbol() {
     return includeSymbol;
   }
+
   @DataBoundSetter
   public void setIncludeSymbol(boolean includeSymbol) {
     this.includeSymbol = includeSymbol;


### PR DESCRIPTION
fixes #290

<!-- Please describe your pull request here. -->

### Testing done
Tested with curl that includeSymbol parameter works as expected

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
