### PR TITLE
Fix stretching of images in Safari

### DIFF
--- a/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.css.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/HeaderRootAction/theme.css.jelly
@@ -19,12 +19,10 @@
 
   svg.custom-header__svg {
     height: var(--header-height);
-    width: fit-content;
   }
 
   .custom-header__image, .custom-header__icon {
     height: var(--logo-dim) !important;
-    width: fit-content;
   }
 
   .custom-header__symbol {


### PR DESCRIPTION
On Safari the `width: fit-content` doesn't work as expected. So just remove it, it works fine without it.

fixes #298

<!-- Please describe your pull request here. -->

### Testing done
Verified with chrome and firefox that svgs and images are properly displayed. Can't test Safari due to lack of a Mac. But expect that it works as the reporter of #298 tested removing the width with inspect tools and confirmed it works.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
