### PR TITLE
Don't try to load custom theme when not set

### DIFF
--- a/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderDecorator.java
+++ b/src/main/java/io/jenkins/plugins/customizable_header/CustomHeaderDecorator.java
@@ -17,6 +17,8 @@ public class CustomHeaderDecorator extends PageDecorator {
     String url = CustomHeaderConfiguration.get().getCssResourceUrl();
     if (!url.isBlank()) {
       RemoteAssetCache.addUrlToCache(url);
+    } else {
+      return null;
     }
     String enc = URLEncoder.encode(url, StandardCharsets.UTF_8);
     return Jenkins.get().getRootUrl() + "customizable-header/fetch?u=" + enc;

--- a/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderDecorator/header.jelly
+++ b/src/main/resources/io/jenkins/plugins/customizable_header/CustomHeaderDecorator/header.jelly
@@ -7,7 +7,7 @@
     <script src="${resURL}/plugin/customizable-header/js/messages.js" type="text/javascript"></script>
   </l:hasPermission>
   <j:if test="${it.enabled}">
-    <j:if test="${it.cssResourceUrl != ''}">
+    <j:if test="${it.cssResourceUrl != null}">
       <link rel="preload" href="${it.cssResourceUrl}" as="style"/>
       <link rel="stylesheet" href="${it.cssResourceUrl}" type="text/css"/>
     </j:if>


### PR DESCRIPTION
After switching to load things from userContent via dedicated fetch endpoint, the logic to not fetch when not defined doesn't work anymore as we would never return an empty string now.

fixes #317

<!-- Please describe your pull request here. -->

### Testing done
Manually verified that the fetch call is no longer there when custom theme is not set, while it is called when the theme is not whitespace only.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
